### PR TITLE
Minor amend to parsing title tags

### DIFF
--- a/service.js
+++ b/service.js
@@ -68,7 +68,7 @@ exports.getPageTitle = function (body) {
 
         var $ = cheerio.load(body);
 
-        return trimText($('title').text());
+        return trimText($('head title').text());
     }
 
 }

--- a/test/fixtures/multiple-titles.html
+++ b/test/fixtures/multiple-titles.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="utf-8" />
+    <title>A page with multiple &lt;title&gt; elements</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+
+  <body>
+
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <symbol viewBox="0 0 15 15" width="100%" height="100%">
+        <title>down-arrow icon</title>
+        <path d="M6.468 0h1.87v10.932l3.145-3.146 1.322 1.322-5.403 5.403L2 9.108l1.322-1.322 3.146 3.146z"
+          fill-rule="evenodd"></path>
+      </symbol>
+    </svg>
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <symbol viewBox="0 0 20 20">
+        <title>chevron-right icon</title>
+        <path d="M6.19 2.587l1.62-1.174 6.46 8.915-6.507 7.688-1.526-1.292 5.493-6.492z">
+        </path>
+      </symbol>
+    </svg>
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <symbol viewBox="0 0 20 20">
+        <title>check icon</title>
+        <path
+          d="M18.038 3.293a1 1 0 0 1 1.414 1.414l-13.24 13.24-5.92-5.92a1 1 0 1 1 1.415-1.415l4.506 4.506L18.038 3.293z">
+        </path>
+      </symbol>
+    </svg>
+
+  </body>
+
+</html>


### PR DESCRIPTION
# Minor amend to parsing title tags

## Description

On pages that include inline SVG, multiple titles may be returned. Examples below. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested

Consider this test file: 

```html
<!DOCTYPE html>
<html lang="en">

  <head>
    <meta charset="utf-8" />
    <title>A page with multiple &lt;title&gt; elements</title>
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
  </head>

  <body>

    <svg xmlns="http://www.w3.org/2000/svg">
      <symbol viewBox="0 0 15 15" width="100%" height="100%">
        <title>down-arrow icon</title>
        <path d="M6.468 0h1.87v10.932l3.145-3.146 1.322 1.322-5.403 5.403L2 9.108l1.322-1.322 3.146 3.146z"
          fill-rule="evenodd"></path>
      </symbol>
    </svg>
    <svg xmlns="http://www.w3.org/2000/svg">
      <symbol viewBox="0 0 20 20">
        <title>chevron-right icon</title>
        <path d="M6.19 2.587l1.62-1.174 6.46 8.915-6.507 7.688-1.526-1.292 5.493-6.492z">
        </path>
      </symbol>
    </svg>
    <svg xmlns="http://www.w3.org/2000/svg">
      <symbol viewBox="0 0 20 20">
        <title>check icon</title>
        <path
          d="M18.038 3.293a1 1 0 0 1 1.414 1.414l-13.24 13.24-5.92-5.92a1 1 0 1 1 1.415-1.415l4.506 4.506L18.038 3.293z">
        </path>
      </symbol>
    </svg>

  </body>

</html>
```

The expected response would be: 

  > “A page with multiple &lt;title&gt; elements”

The actual response you’d get back would be as follows: 

  > “A page with multiple &lt;title&gt; elementsdown-arrow iconchevron-right iconcheck icon”

I came across this while auditing a site which hadn’t hidden the inline SVGs very well, meaning the extra `title` values were leaking out. 

## Solution

Adding some specificity to the selector in `getPageTitle()`.

From: `$('title')`

To: `$('head title')`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
